### PR TITLE
feat/PRI-105 supabase insert data

### DIFF
--- a/vex_app/frontend/src/components/DatePickForm.tsx
+++ b/vex_app/frontend/src/components/DatePickForm.tsx
@@ -60,13 +60,11 @@ export const DatePickerForm = ({ onFormSubmit }:DatePickerFormProps) => {
    * - `DistrictSelectPopover`: 地区を選択するためのポップオーバー
    */
   const auth = useRecoilValue(authState)
-  // const {access_token} = auth.isLoginState
-
   const datePickerForm = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       selectedDate: new Date(),
-      district: '東京都(港区)',
+      district: '',
     }
   });
   const [isLoading, setIsLoading] = useState(false) 
@@ -75,6 +73,8 @@ export const DatePickerForm = ({ onFormSubmit }:DatePickerFormProps) => {
     e.preventDefault() 
     setIsLoading(true)
     const formData = datePickerForm.getValues();
+    const createdAt = new Date().toISOString();
+    const userId = auth.user?.id;
 
     try {
       // フォームデータをサーバーに送信
@@ -87,11 +87,13 @@ export const DatePickerForm = ({ onFormSubmit }:DatePickerFormProps) => {
     // バックエンドのリクエストが成功したら、Supabaseにデータを登録
     if (response.status === 200) {
       const { data, error } = await supabase
-        .from('events')
+        .from('searches')
         .insert([
           { 
-            selectedDate: formData.selectedDate, 
-            district: formData.district
+            user_id: userId,
+            selectedDate: formData.selectedDate,
+            district: formData.district,
+            created_at: createdAt,
           }
         ]);
 

--- a/vex_app/frontend/src/lib/supabase.ts
+++ b/vex_app/frontend/src/lib/supabase.ts
@@ -9,15 +9,19 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
-      events: {
+      searches: {
         Row: {
-          id: number
+          id: string
+          user_id: string
           selectedDate: Date
           district: string
+          created_at: Date
         }
         Insert: {
+          user_id: string
           selectedDate: Date
           district: string
+          created_at: Date
         }
       }
     }


### PR DESCRIPTION
### Background/Context (背景/文脈)
ユーザーごとで検索履歴を残したい
DBはPostgreSQLでRDBMSなので、現在のseachesテーブルにLogin中のユーザーIDを追加する形で対応する

### Goals (この取組みのゴール)
- ユーザーのIDをカラムに含んだ状態で登録

### Non-goals (あえて含めないと決めたこと)
- セキュリティに関してはひとまず後ほど
  - なりすまし防止等

### Dependencies (依存関係)

### Success Metrics (取組みの成功を決める指標)
- DatePickerFormでSubmitして、登録の確認
  - id BIGSERIAL PRIMARY KEY,
  - user_id UUID REFERENCES auth.users(id),
  - selectedDate DATE NOT NULL,
  - district TEXT NOT NULL,
  - created_at TIMESTAMPTZ DEFAULT NOW()