### PR TITLE
feat/PRI-107 add loading screen

### DIFF
--- a/vex_app/frontend/package-lock.json
+++ b/vex_app/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-progress": "^1.0.3",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
@@ -2418,6 +2419,30 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.0.3.tgz",
+      "integrity": "sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/vex_app/frontend/package.json
+++ b/vex_app/frontend/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-progress": "^1.0.3",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",

--- a/vex_app/frontend/src/components/googleMap.tsx
+++ b/vex_app/frontend/src/components/googleMap.tsx
@@ -1,8 +1,10 @@
+import { Progress } from "@/components/ui/progress";
 import { useGoogleMap } from "@/hooks/useGoogleMap";
 import { eventDataState } from "@/state/authState";
 import { useEffect, useRef } from "react";
 import { useRecoilState } from "recoil";
 import { ResetMapButton } from "./ResetMapButton";
+
 
 
 const tokyoTower = {
@@ -34,7 +36,6 @@ export const GoogleMap = ({eventsData}: {eventsData: any[]}) => {
   const [storedEvents, setStoredEvents] = useRecoilState(eventDataState);
   const mapRef = useRef<HTMLDivElement>(null);
   const map = useGoogleMap(import.meta.env.VITE_APP_GOOGLE_MAPS_API_KEY, mapRef, tokyoTower, eventsData);
-  
   useEffect(() => {
     setStoredEvents(eventsData);
     if (map && eventsData.length > 0) {
@@ -94,7 +95,7 @@ export const GoogleMap = ({eventsData}: {eventsData: any[]}) => {
       </div>
 
       <div ref={mapRef} style={{ height: "80vh", width: "100%" }}>
-        Loading...
+        <Progress value={33} />
       </div>
 
     </div>

--- a/vex_app/frontend/src/components/ui/progress.tsx
+++ b/vex_app/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }


### PR DESCRIPTION
### Background/Context (背景/文脈)
- Googlemap描画時、現状ただLoadingと書いているだけで味気ないのでかっこよくしたい

### Goals (この取組みのゴール)
- ShadcnのProgressの導入
https://ui.shadcn.com/docs/components/progress

### Non-goals (あえて含めないと決めたこと)
- 上記以外の変更

### Dependencies (依存関係)
- Googlemap.tsx

### Success Metrics (取組みの成功を決める指標)
- Loading中に[Progress](https://ui.shadcn.com/docs/components/progress)の画面に切り替わる