### PR TITLE
feat/PRI-101 add supabase google auth.

### DIFF
--- a/vex_app/frontend/src/hooks/useGoogleLogin.ts
+++ b/vex_app/frontend/src/hooks/useGoogleLogin.ts
@@ -1,19 +1,28 @@
 import { supabase } from '@/lib/utils';
+import { authState } from '@/state/authState';
+import { useSetRecoilState } from 'recoil';
 
 export const useGoogleLogin = () => {
-    // Googleログイン処理
-  const handleGoogleLogin = async () => {
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-    });
-  
-    if (error) {
-      console.error('Login error:', error.message);
-      alert('Login failed');
-    } else {
-      alert('Login successful');
-      // TODO: ログイン成功後の処理
-    }
-  };
-  return { handleGoogleLogin };
+    const setAuth = useSetRecoilState(authState);
+
+    const handleGoogleLogin = async () => {
+        const { error } = await supabase.auth.signInWithOAuth({
+            provider: 'google',
+        });
+
+        if (error) {
+            console.error('Login error:', error.message);
+            alert(`Login Error: ${error.message}`);
+            return;
+        }
+
+        // リダイレクト後にセッションを確認
+        const currentSession = supabase.auth.getSession();
+        if (currentSession) {
+            alert('Login successful!');
+            setAuth(currentSession);
+        }
+    };
+
+    return { handleGoogleLogin };
 };

--- a/vex_app/frontend/src/hooks/useGoogleSignup.ts
+++ b/vex_app/frontend/src/hooks/useGoogleSignup.ts
@@ -1,20 +1,29 @@
-import { supabase } from "@/lib/utils";
+import { supabase } from '@/lib/utils';
+import { authState } from '@/state/authState';
+import { useSetRecoilState } from 'recoil';
 
 
 export const useGoogleSignup = () => {
-    // Googleログイン処理
-    const handleGoogleSignup = async () => {
+    const setAuth = useSetRecoilState(authState);
+
+    const handleGoogleLogin = async () => {
         const { error } = await supabase.auth.signInWithOAuth({
-          provider: 'google',
+            provider: 'google',
         });
+
         if (error) {
-            console.error('Signup Error:', error);
-            alert(`Signup Error: ${error.message}`);
-        } else {
-            alert('Signup successful');
-            // TODO: ログイン成功後の処理
+            console.error('Login error:', error.message);
+            alert(`Login Error: ${error.message}`);
+            return;
+        }
+
+        // リダイレクト後にセッションを確認
+        const currentSession = supabase.auth.getSession();
+        if (currentSession) {
+            alert('Signup successful!');
+            setAuth(currentSession);
         }
     };
-    return { handleGoogleSignup };
-}
 
+    return { handleGoogleLogin };
+};


### PR DESCRIPTION
### Background/Context (背景/文脈)
もともとLogin画面にGoogleAuthのアイコンを設置していたが、実装が出来なかったのでこれを機に再チャレンジ

### Goals (この取組みのゴール)
- GoogleでのLogin

### Non-goals (あえて含めないと決めたこと)
- Google以外でのLogin処理の変更

### Dependencies (依存関係)
- 現状のLogin処理
- PrivateRoute.tsx
- LoginForm.tsx

### Success Metrics (取組みの成功を決める指標)
- Google認証成功からのHome画面へ遷移